### PR TITLE
Remove unimplemented route.

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,10 +6,6 @@ app.jinja_env.add_extension('pyjade.ext.jinja.PyJadeExtension')
 def index():
     return render_template("index.jade")
 
-@app.route('/dragndrop')
-def dragndrop():
-    return render_template("dragndrop.jade")
-
 if __name__ == "__main__":
     app.debug = True
     app.run()


### PR DESCRIPTION
The dragndrop route slipped in from another project lifetime. Removed it as it's likely a mistake given the page it refers to was excluded from pull request #1
